### PR TITLE
fix with 1.2.0-SNAPSHOT version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-This project illustrates a bug in JSweet's code generation when the output is
+This project illustrates a bug in JSweet's 1.1.x code generation when the output is
 set to AMD modules. Java-side imports from parent packages cause a failure at
 require-load time. Requirejs' loader runs the code for the deepest package first,
 which means the parent package has not yet populated it's exports object.
+
+This bug is not relevant anymore in JSweet >= 1.2 since module generation strategy was full reworked.

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       <plugin>
         <groupId>org.jsweet</groupId>
         <artifactId>jsweet-maven-plugin</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0-SNAPSHOT</version>
         <configuration>
           <verbose>true</verbose>
           <tsOut>target/ts</tsOut>

--- a/src/main/java/com/documill/dependency/Dependency.java
+++ b/src/main/java/com/documill/dependency/Dependency.java
@@ -1,11 +1,10 @@
 
 package com.documill.dependency;
 
-public class Dependency
-{
+public class Dependency {
 
-  public static int dependency()
-  {
-    return 0;
-  }
+	public static int dependency() {
+		System.out.println("called dependency");
+		return 0;
+	}
 }

--- a/src/main/java/com/documill/dependency/problem/Problem.java
+++ b/src/main/java/com/documill/dependency/problem/Problem.java
@@ -3,11 +3,13 @@ package com.documill.dependency.problem;
 
 import com.documill.dependency.Dependency;
 
-public class Problem
-{
+public class Problem {
 
-  public static void problem()
-  {
-    Dependency.dependency();
-  }
+	public static void main(String[] args) {
+		problem();
+	}
+
+	public static void problem() {
+		Dependency.dependency();
+	}
 }

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -6,7 +6,7 @@
 </head>
 <body>
   <script type="text/javascript">  
-  require(["../target/js/module"], function(jsweet) {
+  require(["../target/js/com/documill/dependency/problem/Problem"], function(jsweet) {
     console.log(jsweet);
   });
   </script>


### PR DESCRIPTION
This PR (which you don't have to merge as is) demonstrate the changes in JSweet version 1.2. It should make this bug irrelevant (since the module generation strategy has changed).
